### PR TITLE
Feat: Implement robust 3-point audio language auto-detect with majority voting when no metadata, and add manual CLI override

### DIFF
--- a/anchor/core/audiosync/audiosync.py
+++ b/anchor/core/audiosync/audiosync.py
@@ -104,20 +104,35 @@ def run_audiosync(args, device, model_size, compute_type, batch_size, translatio
         console.print(f"\n[bold reverse] Task {i}/{len(queue)} [/bold reverse] [cyan]{sub.name}[/cyan]")
         console.print(f"🎬 Video: [yellow]{vid.name}[/yellow]")
         
-        # Detection
-        meta_lang = get_audio_language(vid) 
-        if meta_lang:
-            console.print(f"[dim]🌐 Metadata language detected: [bold cyan]{meta_lang.upper()}[/bold cyan][/dim]")
+    # Detection & Language Override
+        audio_lang = None
+
+        # Priority 1: Check if the user manually specified the language via CLI
+        if getattr(args, "audio_language", None):
+            audio_lang = args.audio_language.lower()
+            console.print(f"[dim]🌐 Audio language manually overridden to: [bold cyan]{audio_lang.upper()}[/bold cyan][/dim]")
         else:
-            console.print("[dim]🌐 Language metadata missing. Using Auto-detect.[/dim]")
+            # Priority 2: Attempt to read language from video metadata
+            audio_lang = get_audio_language(vid)
+            if audio_lang:
+                console.print(f"[dim]🌐 Metadata language detected: [bold cyan]{audio_lang.upper()}[/bold cyan][/dim]")
+            else:
+                # Priority 3: True auto-detect by sampling the audio if metadata is missing
+                console.print("[dim]🌐 Language metadata missing. Auto-detecting via audio sample...[/dim]")
+                from ...utils.whisper import detect_audio_language_whisper
+                audio_lang = detect_audio_language_whisper(vid, device, compute_type)
+                console.print(f"[dim]🌐 Whisper Auto-detected audio: [bold cyan]{audio_lang.upper()}[/bold cyan][/dim]")
 
         sub_lang = get_subtitle_language(sub)
-        console.print(f"[dim]📄 Subtitle language detected: [bold cyan]{sub_lang.upper()}[/bold cyan][/dim]")    
+        console.print(f"[dim]📄 Subtitle language detected: [bold cyan]{sub_lang.upper()}[/bold cyan][/dim]")
 
         needs_translation = False
-        if meta_lang and sub_lang != "unknown" and meta_lang != sub_lang:
-            console.print(f"[dim]⚠️ Mismatch detected: Audio is {meta_lang.upper()}, Subtitle is {sub_lang.upper()}. Needs translation.[/dim]")
+        if audio_lang and sub_lang != "unknown" and audio_lang != sub_lang:
+            console.print(f"[dim]⚠️ Mismatch detected: Audio is {audio_lang.upper()}, Subtitle is {sub_lang.upper()}. Needs translation.[/dim]")
             needs_translation = True
+
+        # Re-assign to meta_lang to maintain compatibility with the rest of the script
+        meta_lang = audio_lang
 
         # Default: Sync the original file path
         sub_input_for_sync = sub      

--- a/anchor/utils/args.py
+++ b/anchor/utils/args.py
@@ -81,6 +81,14 @@ def parse_arguments():
         action="store_true",
         help="Enable API mode.",
         default=False
+
     )
+    # Allows users to bypass metadata and force a specific audio language (useful for broken metadata)
+    parser.add_argument(
+        "--audio-language",
+        type=str,
+        help="Manually specify the video's audio language (e.g. 'en', 'sv') bypassing metadata."
+)
+
     
     return parser.parse_args()

--- a/anchor/utils/whisper.py
+++ b/anchor/utils/whisper.py
@@ -10,6 +10,11 @@ from .ui import make_ui_console, CaptureProgress
 from .files import open_subtitle
 from .alignment import GlobalAligner
 
+#for auto-detect-fix
+import ffmpeg
+import numpy as np
+from collections import Counter
+
 console = Console()
 
 def load_whisper_model(device, compute_type, language, model_size="large-v3"):
@@ -189,3 +194,62 @@ def run_anchor_sync(video_path, sub_path, device, compute_type, batch_size, mode
     
     return output_path, len(original_subs), rejected
     
+
+def detect_audio_language_whisper(video_path, device, compute_type):
+    """
+    Extracts three 30-second audio samples (at 30%, 50%, and 70%) and uses WhisperX
+    to detect the language, using a majority vote to ensure high accuracy.
+    """
+    try:
+        # Probe the video (silently) to find its total duration
+        probe = ffmpeg.probe(str(video_path), v='error')
+        duration = float(probe['format']['duration'])
+
+        # Define our three jump points (30%, 50%, 70%)
+        fractions = [0.3, 0.5, 0.7]
+        detected_languages = []
+
+        # Load the model ONCE outside the loop to save massive amounts of time
+        model = whisperx.load_model("base", device, compute_type=compute_type, asr_options={"without_timestamps": True})
+
+        # Loop through our three points in the video
+        for frac in fractions:
+            start_time = duration * frac
+
+            try:
+                # Extract 30 seconds, silencing FFmpeg
+                out, _ = (
+                    ffmpeg
+                    .input(str(video_path), ss=start_time, t=30)
+                    .output('-', format='s16le', acodec='pcm_s16le', ac=1, ar='16k')
+                    .global_args('-loglevel', 'error')
+                    .run(capture_stdout=True, capture_stderr=True)
+                )
+
+                # Convert the raw audio buffer
+                audio = np.frombuffer(out, np.int16).flatten().astype(np.float32) / 32768.0
+
+                # Analyze this specific clip
+                result = model.transcribe(audio)
+
+                # If speech was found, add it to our voting pool
+                if "language" in result and result["language"] != "unknown":
+                    detected_languages.append(result["language"])
+
+            except Exception:
+                # If one specific clip fails (e.g., end of file), just ignore it and try the next
+                continue
+
+        # --- THE VOTING SYSTEM ---
+        if detected_languages:
+            # Counter counts occurrences. most_common(1) returns e.g., [('en', 2)]
+            # We then extract just the language code from that nested result.
+            winner = Counter(detected_languages).most_common(1)[0][0]
+            return winner
+        else:
+            # Absolute fallback if ALL three clips were purely silent
+            return "en"
+
+    except Exception as e:
+        # Fallback if the entire file is unreadable
+        return "en"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ requests
 fastapi
 uvicorn
 pydantic
+ffmpeg-python


### PR DESCRIPTION
Hi! 
This is a fix for my reported issue https://github.com/ellite/anchor-sub-sync/issues/3#issue-4185209241

This PR adds an auto-detect feature for files missing language metadata. It uses WhisperX to sample three separate 30-second clips (at 30%, 50%, and 70% of the video, purposefully avoiding intros/studio logos) and uses majority voting to determine the correct language.

It also adds an --audio-language flag for manual overrides.

It works real nice from what I've been able to test, does not add that much time at all (none if lang metadata already exists of course)

Let me know what you think