### PR TITLE
Feat: Add safety backup (.bak) when using --overwrite flag in audio and reference sync

### DIFF
--- a/anchor/core/audiosync/audiosync.py
+++ b/anchor/core/audiosync/audiosync.py
@@ -2,6 +2,7 @@ import sys
 import time
 import gc
 import torch
+import shutil
 import pysubs2
 from pathlib import Path
 from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn, BarColumn, TaskProgressColumn
@@ -120,12 +121,20 @@ def run_audiosync(args, device, model_size, compute_type, batch_size, translatio
             needs_translation = True
 
         # Default: Sync the original file path
-        sub_input_for_sync = sub      
-        
+        sub_input_for_sync = sub
+
+        # If the user enabled overwrite, create a backup of the original file now
+        if getattr(args, "overwrite", False):
+            backup_path = sub.with_name(f"{sub.name}.bak")
+            # Only create backup if the original file exists and no backup exists yet
+            if sub.exists() and not backup_path.exists():
+                shutil.copy(sub, backup_path)
+                console.print(f"[dim]📦 Created backup of original: {backup_path.name}[/dim]")
+
         # Variables for cleanup later
-        original_sub_object = None    
-        ghost_file_path = None        
-        
+        original_sub_object = None
+        ghost_file_path = None
+
         # Translation
         if needs_translation:
             # Load the ORIGINAL content into memory now

--- a/anchor/core/referencesync/referencesync.py
+++ b/anchor/core/referencesync/referencesync.py
@@ -1,6 +1,7 @@
 import sys
 import time
 import pysubs2
+import shutil
 from pathlib import Path
 from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn, BarColumn, TaskProgressColumn
 
@@ -99,7 +100,15 @@ def run_referencesync(args, device, translation_model, console):
             console.print(f"[dim]⚠️ Mismatch detected. Translating Target ({target_lang.upper()}) to match Reference ({ref_lang.upper()}).[/dim]")
             needs_translation = True
 
-        sub_input_for_sync = target_sub      
+        # If the user enabled overwrite, create a backup of the target file now
+        if getattr(args, "overwrite", False):
+            backup_path = target_sub.with_name(f"{target_sub.name}.bak")
+            # Only create backup if the original file exists and no backup exists yet
+            if target_sub.exists() and not backup_path.exists():
+                shutil.copy(target_sub, backup_path)
+                console.print(f"[dim]📦 Created backup of original: {backup_path.name}[/dim]")
+
+        sub_input_for_sync = target_sub
         original_sub_object = None    
         ghost_file_path = None        
         


### PR DESCRIPTION
This PR adds a safety measure to the existing --overwrite functionality. Previously, the original subtitle was overwritten immediately. Now, a .bak backup of the original file is created before any sync or translation takes place, preventing accidental data loss.