### PR TITLE
feat: improve language detection with multi-sampling

### DIFF
--- a/anchor/utils/whisper.py
+++ b/anchor/utils/whisper.py
@@ -4,6 +4,7 @@ import time
 import os
 import torch
 import whisperx
+from collections import Counter
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, BarColumn, TextColumn, TimeElapsedColumn
 from .ui import make_ui_console, CaptureProgress
@@ -49,6 +50,53 @@ def load_whisper_model(device, compute_type, language, model_size="large-v3"):
 
     return model
 
+def detect_robust_language(model, audio, batch_size):
+    """
+    Samples three 30-second snippets from the audio (15%, 50%, 85%)
+    and runs a quick transcription to determine the language.
+    Returns the most common detected language, or None if it fails.
+    """
+    sample_rate = 16000
+    duration_sec = len(audio) / sample_rate
+
+    # If the video is shorter than 2 minutes, let Whisper handle it natively
+    if duration_sec < 120:
+        return None
+
+    timestamps = [0.15, 0.50, 0.85]
+    guesses = []
+
+    for pct in timestamps:
+        start_sample = int(pct * duration_sec * sample_rate)
+        end_sample = start_sample + (30 * sample_rate)
+
+        # Ensure we don't go out of bounds
+        if end_sample > len(audio):
+            end_sample = len(audio)
+
+        audio_snippet = audio[start_sample:end_sample]
+
+        try:
+            # Run transcription silently to extract language guess
+            result = model.transcribe(
+                audio_snippet,
+                batch_size=batch_size,
+                language=None,
+                print_progress=False, # Mute progress bar
+                combined_progress=False
+            )
+            detected = result.get("language")
+            if detected and detected != "unknown":
+                guesses.append(detected)
+        except Exception:
+            continue
+
+    if not guesses:
+        return None
+
+    # Return the most frequent guess (majority voting)
+    return Counter(guesses).most_common(1)[0][0]
+
 def run_whisper_transcription(video_path, device, compute_type, batch_size, model, language=None):
     """Transcribes audio and aligns phonemes. Returns (whisper_data, detected_lang) or (None, None) on failure."""
     safe_console = Console(force_terminal=True)
@@ -60,7 +108,15 @@ def run_whisper_transcription(video_path, device, compute_type, batch_size, mode
 
     result = None
     current_batch_size = batch_size
+
     is_windows = (os.name != 'posix')
+
+    if language is None:
+        console.print("[dim]🔍 Auto-detecting language via multiple samples...[/dim]")
+        robust_lang = detect_robust_language(model, audio, current_batch_size)
+        if robust_lang:
+            language = robust_lang
+            console.print(f"[dim]🌐 Robust auto-detect determined: [bold cyan]{language.upper()}[/bold cyan][/dim]")
 
     while current_batch_size >= 1:
         try:

--- a/anchor/utils/whisper.py
+++ b/anchor/utils/whisper.py
@@ -112,7 +112,7 @@ def run_whisper_transcription(video_path, device, compute_type, batch_size, mode
     is_windows = (os.name != 'posix')
 
     if language is None:
-        console.print("[dim]🔍 Auto-detecting language via multiple samples...[/dim]")
+        console.print("[dim]🔍 Auto-detecting language via three separate samples...[/dim]")
         robust_lang = detect_robust_language(model, audio, current_batch_size)
         if robust_lang:
             language = robust_lang


### PR DESCRIPTION
### Description
The new auto-detect works great, but has a hidden flaw: when `language=None`, Whisper natively limits its language detection to the **first 30 seconds** of the audio. 

If a video starts with silent logos, long musical intros, or background noise, Whisper often hallucinates a random language (e.g., guessing Thai for a Swedish video). Because Whisper locks in its first guess for the entire file, this ruins the transcription and triggers unnecessary translation logic.

### Solution
This PR bypasses Whisper's  30-second limitation with a lightweight `detect_robust_language` helper function that samples three snippets from the file. Instead of trusting just the first 30 seconds, it:
1. Samples **three** 30-second snippets (at 15%, 50%, and 85%).
2. Silently runs `model.transcribe()` on them.
3. Uses majority voting to determine the true language.
4. Falls back to native detection for videos under 2 minutes.

**Why this approach?**
Since the `audio` is already loaded as a numpy array, slicing it and running inference on these snippets takes only a fraction of a second and requires no external dependencies (like `ffmpeg`). 

### Changes Made
- Added `detect_robust_language` in `whisper.py`
- Injected the check before the main `model.transcribe` call (when no metadata is present).
- Muted the progress bar for the detection samples.

Sounds good, no? 😃